### PR TITLE
okuda

### DIFF
--- a/HEW/Core/MyList.cpp
+++ b/HEW/Core/MyList.cpp
@@ -336,7 +336,7 @@ void MyListDeleteObjectAll(MyList list)
 {
 	ListManager *manager = (ListManager*)list;
 
-	if (manager->ListData.numObj != 0)
+	while(manager->ListData.numObj != 0)
 	{
 		DelObjAndPool(manager, manager->Top_pt);
 	}

--- a/HEW/Phase/Phase_Title.cpp
+++ b/HEW/Phase/Phase_Title.cpp
@@ -93,15 +93,15 @@ void UpdateTitle()
 		return;
 	}
 
+	SetTitle3DEffect();
+	SetTitle3DEffect();
+	SetTitle3DEffect();
+
 	// 次のフェーズに行く
-	//if (GetKeyboardTrigger(DIK_RETURN))
+	if (GetKeyboardTrigger(DIK_RETURN))
 	{	// タックル１
 		//GoNextPhase(GetPhaseGameTackle1Func());
-		//GoNextPhase(GetPhaseTitleFunc());
-		//SetTitle3DEffect();
-		SetTitle3DEffect();
-		SetTitle3DEffect();
-
+		GoNextPhase(GetPhaseTitleFunc());
 	}
 
 	if (GetKeyboardPress(DIK_LEFT))


### PR DESCRIPTION
MylistDeleteObjectAll関数が正常に機能しないバグの修正
スケール行列の演算短縮のため事前演算させるように（高速化)